### PR TITLE
Fixed bugs related to the BC step

### DIFF
--- a/kpcfit/kpcfit_manual.m
+++ b/kpcfit/kpcfit_manual.m
@@ -80,7 +80,7 @@ else
 end
 
 %% determine best result
-[v,ind] = sort(fobjBC,2,'ascend');
+[v,ind] = sort(fobjBC,1,'ascend'); 
 bestpos = ind(1);
 fac = fobjAC(bestpos);
 fbc = fobjBC(bestpos);


### PR DESCRIPTION
Fixes various issues related to the BC step of KPC-Toolbox:

- the starting point `x0` used by `fmincon` was never updated. Now it is updated randomly (it could be done in a smarter way anyway)
- at the end of the BC step, the objective function values were not sorted correctly, hence the tool did not pick the best set of MAPs to be composed
- the number of iterations performed by each BC run was not displayed correctly